### PR TITLE
Fix absolute pathing when Python used from an environment variable

### DIFF
--- a/unpacker/hermes_ransomware/dump.py
+++ b/unpacker/hermes_ransomware/dump.py
@@ -1,4 +1,4 @@
-
+import os
 import sys
 import time
 import winappdbg
@@ -134,7 +134,8 @@ def simple_debugger(filename):
   except:
     traceback.print_exc()
   with winappdbg.Debug(handler,bKillOnExit = True) as debug:
-    debug.execl(filename)
+    abspath = os.path.abspath(filename)
+    debug.execl(os.path.join(os.path.dirname(abspath), filename))
     debug.loop()
 
 simple_debugger(sys.argv[1])


### PR DESCRIPTION
Fixes the below exception.

![image](https://user-images.githubusercontent.com/5551512/50563210-65b3ca80-0ce0-11e9-978d-9bbb42419505.png)
